### PR TITLE
add no_tag option

### DIFF
--- a/lib/domo.ex
+++ b/lib/domo.ex
@@ -438,15 +438,20 @@ defmodule Domo do
       imports = [
         deftag: 2,
         for_type: 1,
-        tag: 2,
         untag!: 2
       ]
 
       imports =
         imports ++
-          case Keyword.fetch(opts, :no_field) do
-            {:ok, true} -> []
-            _ -> [typedstruct: 1, field: 2, field: 3]
+          if Keyword.get(opts, :no_field) do
+            []
+          else
+            [typedstruct: 1, field: 2, field: 3]
+          end ++
+          if Keyword.get(opts, :no_tag) do
+            []
+          else
+            [tag: 2]
           end
 
       quote do

--- a/test/domo/options_test.exs
+++ b/test/domo/options_test.exs
@@ -3,7 +3,7 @@ defmodule Domo.OptionsTest do
 
   import ExUnit.CaptureIO
 
-  describe "use Domo with no_filed option" do
+  describe "use Domo with no_field option" do
     test "when set to true should prevent import of typedstruct and field macros" do
       assert_raise CompileError, ~r/undefined function typedstruct/, fn ->
         defmodule ModuleNoTypedstruct do
@@ -33,6 +33,26 @@ defmodule Domo.OptionsTest do
       end
 
       assert is_struct(ModuleTypedstructAndField.new!(field: 1))
+    end
+  end
+
+  describe "use Domo with no_tag option" do
+    test "when set to true should not import the tag/2 macro" do
+      assert_raise CompileError, ~r/undefined function tag/, fn ->
+        defmodule ModuleWithoutTag do
+          use Domo, no_tag: true
+          deftag Id, for_type: integer
+          inspect(tag(123, Id))
+        end
+      end
+    end
+
+    test "when set to false should import the tag/2 macro" do
+      defmodule ModuleWithoutTag do
+        use Domo, no_tag: false
+        deftag Id, for_type: integer
+        inspect(tag(123, Id))
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds the possibility to disable the import of `Domo.tag/2`. Users can run into problems when working with the `view_helpers` imports of Phoenix, because this function imports [Phoenix.HTML.Tag.html#tag/2](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Tag.html#tag/2) (which collides with `Domo.tag/2`).