### PR TITLE
fix: generate manifest files per umbrella application

### DIFF
--- a/lib/domo/type_ensurer_factory/resolve_planner.ex
+++ b/lib/domo/type_ensurer_factory/resolve_planner.ex
@@ -317,7 +317,9 @@ defmodule Domo.TypeEnsurerFactory.ResolvePlanner do
       plan_binary = :erlang.term_to_binary(state.plan)
       preconds_binary = :erlang.term_to_binary(state.preconds)
 
-      with :ok <- File.write(state.plan_path, plan_binary),
+      with :ok <- File.mkdir_p(Path.dirname(state.plan_path)),
+           :ok <- File.mkdir_p(Path.dirname(state.preconds_path)),
+           :ok <- File.write(state.plan_path, plan_binary),
            :ok <- File.write(state.preconds_path, preconds_binary) do
         if state.verbose? do
           IO.write("""

--- a/lib/mix/tasks.compile.domo_compiler.ex
+++ b/lib/mix/tasks.compile.domo_compiler.ex
@@ -298,7 +298,23 @@ defmodule Mix.Tasks.Compile.DomoCompiler do
   def preconds_manifest, do: @preconds_manifest
 
   def manifest_path(mix_project, manifest_kind) do
-    Path.join(mix_project.build_path(), manifest(manifest_kind))
+    [
+      mix_project.build_path(),
+      "domo",
+      mix_application(mix_project),
+      manifest(manifest_kind)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Path.join()
+  end
+
+  defp mix_application(mix_project) do
+    mix_project.config()
+    |> Keyword.get(:app, nil)
+    |> case do
+      nil -> nil
+      app -> to_string(app)
+    end
   end
 
   defp manifest(kind) do

--- a/test/domo/tasks.compile.domo_test.exs
+++ b/test/domo/tasks.compile.domo_test.exs
@@ -673,6 +673,7 @@ defmodule Domo.MixTasksCompileDomoTest do
       deps_file: deps_file,
       code_path: code_path
     } do
+      File.mkdir_p!(Path.dirname(plan_file))
       File.touch!(plan_file)
       File.touch!(types_file)
       File.touch!(preconds_file)

--- a/test/domo/type_ensurer_factory/batch_ensurer_test.exs
+++ b/test/domo/type_ensurer_factory/batch_ensurer_test.exs
@@ -73,6 +73,7 @@ defmodule Domo.TypeEnsurerFactory.BatchEnsurerTest do
     end
 
     test "return the error if no fields in plan are found", %{plan_file: plan_file} do
+      File.mkdir_p!(Path.dirname(plan_file))
       File.write!(plan_file, :erlang.term_to_binary(%{}))
 
       assert {:error,

--- a/test/domo/type_ensurer_factory/generator_test.exs
+++ b/test/domo/type_ensurer_factory/generator_test.exs
@@ -16,6 +16,7 @@ defmodule Domo.TypeEnsurerFactory.GeneratorTest do
     types_content = tags.types_content
 
     unless is_nil(types_content) do
+      File.mkdir_p!(Path.dirname(types_file))
       File.write!(types_file, :erlang.term_to_binary(types_content))
     end
 

--- a/test/domo/type_ensurer_factory/resolve_planner_test.exs
+++ b/test/domo/type_ensurer_factory/resolve_planner_test.exs
@@ -327,6 +327,7 @@ defmodule Domo.TypeEnsurerFactory.ResolvePlannerTest do
           }
         })
 
+      File.mkdir_p!(Path.dirname(plan_path))
       File.write!(plan_path, plan_binary)
 
       {:ok, pid} = ResolvePlanner.start(plan_path, preconds_path, [])
@@ -416,6 +417,7 @@ defmodule Domo.TypeEnsurerFactory.ResolvePlannerTest do
     test "be able to merge preconds with the preconds from disk", %{plan_path: plan_path, preconds_path: preconds_path} do
       preconds_binary = :erlang.term_to_binary(%{IncorrectDefault => [field: "&byze_site(&1) == 150"]})
 
+      File.mkdir_p!(Path.dirname(preconds_path))
       File.write!(preconds_path, preconds_binary)
 
       {:ok, pid} = ResolvePlanner.start(plan_path, preconds_path, [])

--- a/test/domo/type_ensurer_factory/resolver/module_deps_test.exs
+++ b/test/domo/type_ensurer_factory/resolver/module_deps_test.exs
@@ -266,6 +266,8 @@ defmodule Domo.TypeEnsurerFactory.Resolver.ModuleDepsTest do
         {SomeModule, ModuleInspector.beam_types_hash(SomeModule)}
       ]
 
+      File.mkdir_p!(Path.dirname(deps_file))
+
       File.write!(
         deps_file,
         :erlang.term_to_binary(%{


### PR DESCRIPTION
I was having issues when using domo in multiple apps in the context of an umbrella project.
When attempting to compiling only one of the umbrella apps it would find modules in the meta files only available in the other umbrella app, attempting to fetch it's type information but failing because the required GenServer is missing.

This is what the error looks like for me before applying this patch:
```
$ mix compile # <- build the full umbrella, this always works
$ cd apps/app_a
$ mix compile # <- build only app_a, this fails when there are manifest files containing other apps 
** (exit) exited in: GenServer.call(Domo.TypeEnsurerFactory.ResolvePlanner, {:get_types, AnamnesisApiClient.Api.V1.CreateAnamnesis.Response}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.13.3) lib/gen_server.ex:1019: GenServer.call/3
    (domo 1.5.2) lib/domo/type_ensurer_factory/module_inspector.ex:20: Domo.TypeEnsurerFactory.ModuleInspector.beam_types_hash/1
    (domo 1.5.2) lib/domo/type_ensurer_factory/dependency_resolver.ex:130: anonymous fn/3 in Domo.TypeEnsurerFactory.DependencyResolver.remove_modules_with_unloadable_types/2
    (stdlib 3.17.1) maps.erl:410: :maps.fold_1/3
    (domo 1.5.2) lib/domo/type_ensurer_factory/dependency_resolver.ex:96: Domo.TypeEnsurerFactory.DependencyResolver.maybe_cleanup_deps/4
    (domo 1.5.2) lib/domo/type_ensurer_factory/dependency_resolver.ex:17: Domo.TypeEnsurerFactory.DependencyResolver.maybe_recompile_depending_structs/3
    (domo 1.5.2) lib/domo/type_ensurer_factory.ex:363: Domo.TypeEnsurerFactory.recompile_depending_structs/4
    (domo 1.5.2) lib/mix/tasks.compile.domo_compiler.ex:93: Mix.Tasks.Compile.DomoCompiler.build_ensurer_modules/2
```

The idea is to split the manifest files seperate per mix application and therefore avoid the conflicts.
This might be a crude solution, since I don't know the inner workings of this library.
It was merely the first thing I tried and it solves the issue.