### PR TITLE
Make Domo compiler pass on Elixir warnings

### DIFF
--- a/lib/mix/tasks.compile.domo_compiler.ex
+++ b/lib/mix/tasks.compile.domo_compiler.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Compile.DomoCompiler do
     error
   end
 
-  def process_plan(_status_diagnostic, args) do
+  def process_plan(status_diagnostic, args) do
     plan_path = manifest_path(@mix_project, :plan)
     preconds_path = manifest_path(@mix_project, :preconds)
     types_path = manifest_path(@mix_project, :types)
@@ -74,7 +74,14 @@ defmodule Mix.Tasks.Compile.DomoCompiler do
 
     maybe_print_errors(result)
 
-    result
+    merge_diagnostics(result, status_diagnostic)
+  end
+
+  defp merge_diagnostics({domo_status, domo_diagnostics}, {_elixir_status, elixir_diagnostics}) when domo_status in [:ok, :error] do
+    {domo_status, domo_diagnostics ++ elixir_diagnostics}
+  end
+  defp merge_diagnostics({:noop, domo_diagnostics}, {elixir_status, elixir_diagnostics}) do
+    {elixir_status, domo_diagnostics ++ elixir_diagnostics}
   end
 
   def stop_plan_collection do

--- a/test/mix/tasks.compile.domo_compiler_test.exs
+++ b/test/mix/tasks.compile.domo_compiler_test.exs
@@ -119,6 +119,14 @@ defmodule Domo.MixTasksCompileDomoCompilerTest do
       assert_called ResolvePlanner.ensure_flushed_and_stopped(any())
     end
 
+    test "pass on warnings from elixir" do
+      DomoMixTask.start_plan_collection()
+
+      warn = {:ok, [:diagnostic]}
+      assert DomoMixTask.process_plan(warn, []) == warn
+      assert_called ResolvePlanner.ensure_flushed_and_stopped(any())
+    end
+
     test "set the plan collection flag to true on run and to false on process plan" do
       assert CodeEvaluation.in_plan_collection?() == false
 


### PR DESCRIPTION
The Domo Mix compiler properly stops on error messages from the Elixir compiler, but warnings are consumed and never returned.
When running mix from the command line this is not a big issue, as the warnings are printed out. When using ElixirLS, however, the Elixir warnings will not properly show up, if the Domo compiler does not emit them again.

This pull-request ensures that incoming diagnostics (from the ELixir compiler) are properly merged with Domo diagnostics.