### PR TITLE
Allow for more recent nimble_parsec versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,10 @@ Domo compiled validation functions for the given struct based on the described t
 
 ## Changelog
 
+## v1.5.16
+
+* Allow latest dependencies for projects with Elixir > 12
+
 ## v1.5.15
 
 * Support sum types as element of a list: [a | b]

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule Domo.MixProject do
       {:placebo, "~> 1.2", only: :test},
       {:ecto, ">= 0.0.0", optional: true},
       {:decimal, ">= 0.0.0", optional: true},
-      {:nimble_parsec, "1.1.0"},
+      {:nimble_parsec, "~> 1.1"},
 
       # Documentation dependencies
       {:ex_doc, "0.26.0", only: :docs, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Domo.MixProject do
   use Mix.Project
 
-  @version "1.5.15"
+  @version "1.5.16"
   @repo_url "https://github.com/IvanRublev/Domo"
 
   def project do
@@ -62,18 +62,30 @@ defmodule Domo.MixProject do
     [
       # Development and test dependencies
       {:ex_check, ">= 0.0.0", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.3", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: :dev, runtime: false},
       {:excoveralls, "~> 0.13.4", only: :test, runtime: false},
       {:mix_test_watch, "~> 1.0", only: :test, runtime: false},
       {:placebo, "~> 1.2", only: :test},
       {:ecto, ">= 0.0.0", optional: true},
       {:decimal, ">= 0.0.0", optional: true},
-      {:nimble_parsec, "~> 1.1"},
-
+      {:nimble_parsec, if(ex_before_12?(), do: "1.1.0", else: "~> 1.1")},
       # Documentation dependencies
-      {:ex_doc, "0.26.0", only: :docs, runtime: false}
+      {:ex_doc, if(ex_before_12?(), do: "0.26.0", else: "~> 0.26.0"), only: :docs, runtime: false}
     ]
+  end
+
+  defp ex_before_12? do
+    [1, minor, _] = ex_version()
+    minor < 12
+  end
+
+  defp ex_version do
+    :elixir
+    |> Application.spec(:vsn)
+    |> to_string()
+    |> String.replace(~r/-.*$/, "")
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
   end
 
   defp aliases do


### PR DESCRIPTION
Hi :wave: thanks for this library.

I saw that a7a876f055947bbadeadd011b43ad34a9164deda added `nimble_parsec` as a dependency. I was just surprised that it seemed to pin down a rather old version of it. Is there a reason for it? All checks seems to be passing locally with `1.4.0`.Could we allow more recent versions to be used?

Thanks in advance.