### PR TITLE
[Fix-37] Deal with compilation issues on elixir 1.19.rc2

### DIFF
--- a/lib/compile_stdlib_type_ensurers.ex
+++ b/lib/compile_stdlib_type_ensurers.ex
@@ -13,6 +13,11 @@ wait_for_list =
   |> Enum.map(&(&1 |> Path.basename() |> String.replace_suffix(extension, "") |> Macro.camelize()))
   |> Enum.map(&Module.concat(parent_module, &1))
 
+# Also ensure all required modules are compiled
+Code.ensure_compiled(Domo.TypeEnsurerFactory.Atomizer)
+Code.ensure_compiled(Domo.TypeEnsurerFactory.Precondition)
+Code.ensure_compiled(Domo.TypeEnsurerFactory.Generator.TypeSpec)
+
 Enum.each(wait_for_list, &Code.ensure_compiled/1)
 
 verbose? = false

--- a/lib/domo/type_ensurer_factory/batch_ensurer.ex
+++ b/lib/domo/type_ensurer_factory/batch_ensurer.ex
@@ -52,7 +52,7 @@ defmodule Domo.TypeEnsurerFactory.BatchEnsurer do
   defp wrap_error(errors) do
     errors
     |> List.wrap()
-    |> Enum.map(&%Error{&1 | compiler_module: __MODULE__})
+    |> Enum.map(&Map.put(&1, :compiler_module, __MODULE__))
   end
 
   defp do_ensure_structs_integrity([{module, fields, file, line} | tail]) do

--- a/lib/domo/type_ensurer_factory/resolver.ex
+++ b/lib/domo/type_ensurer_factory/resolver.ex
@@ -18,7 +18,7 @@ defmodule Domo.TypeEnsurerFactory.Resolver do
       :ok
     else
       {:error, errors} ->
-        {:error, errors |> List.wrap() |> Enum.map(&%Error{&1 | compiler_module: __MODULE__})}
+        {:error, errors |> List.wrap() |> Enum.map(&Map.put(&1, :compiler_module, __MODULE__))}
     end
   end
 


### PR DESCRIPTION
Handles compilation compatibility issues with Elixir 1.19

- 2 cases of using the struct update synthax
- 1 case of modules not compiling due to circular dependencies apparently being resolved differently?

_Disclaimer: I have 7-9 failing tests here that I don't think are caused by this, but I'll spend a bit more time trying to get to the bottom off. If the Code.ensure_loaded changes are outright wrong, feel free to close._

EDIT: Closed, as it's deeper than I thought. Don't have the time to commit to it right now.